### PR TITLE
Update 1.6-Forms-in-Table-Builder.md

### DIFF
--- a/labs/telework-vancouver/1.0-Build-the-Foundation/1.6-Forms-in-Table-Builder.md
+++ b/labs/telework-vancouver/1.0-Build-the-Foundation/1.6-Forms-in-Table-Builder.md
@@ -2,7 +2,7 @@
 id: forms-in-table-builder
 title: "1.6 Configure Arrangement Form"
 hide_table_of_contents: true
-draft: false
+draft: true
 ---
 
 ## Overview


### PR DESCRIPTION
Section is no longer needed. Changing to draft to hide.