### PR TITLE
Teleworks 101 quick updates 

### DIFF
--- a/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.2-create-the-app.md
+++ b/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.2-create-the-app.md
@@ -38,7 +38,7 @@ Only the Owner of the application and invited Collaborators can make changes in 
      |Field|Value 
      |--|--
      |**Name** | `Telework Case Management` 
-     |**Value**| `Manage Telework requests across departments`
+     |**Description**| `Manage Telework requests across departments`
 
    - Upload the **App_Logo.png** file you downloaded.
    ![](../images/2023-11-04-17-18-04.png)

--- a/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.3-import-data.md
+++ b/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.3-import-data.md
@@ -213,7 +213,7 @@ Days per week is ok as an integer. **Do not do anything to it.**
 ![](../images/2023-11-02-21-20-14.png)
 
 
-24. **Modify Field Type**: Change 'Justification' from from `String` to `Reference`.
+24. **Modify Field Type**: Change 'Justification' from `String` to `Reference`.
      1. Hover over the row and edit the field **Justification** by clicking on the pencil icon.
      ![](../images/2023-11-02-21-22-15.png)
      2. Click "String" under **Field type** and change it to **Reference**.
@@ -264,4 +264,4 @@ Well done! You've have imported the spreadsheet used by Amanda and her team to t
 
 The `Telework Case` table references the `Justification` and `Arrangement` tables.  This will help ensure data input consistency. 
 
-Since `Justification` and `Arrangement` are standalone table, you can easily add or remove entries in production. This means the choices can be adjusted without the need to deploy a new version of the application.
+Since `Justification` and `Arrangement` are standalone tables, you can easily add or remove entries in production. This means the choices can be adjusted without the need to deploy a new version of the application.

--- a/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.5-configure-telework-form.md
+++ b/labs/telework-vancouver-101/1.0-Build-the-Foundation/1.5-configure-telework-form.md
@@ -13,7 +13,7 @@ In this exercise, we will focus on creating a new default form unique to the `Te
 
 This form view is the 'back-end' view that will be visible in the Platform to the **fulfillers** working on the Telework Cases. 
 
-The **fulfiller** have asked that the following fields be added to the form:
+The **fulfillers** have asked that the following fields be added to the form:
 * Opened by
 * Arrangement
 * Days per week
@@ -87,7 +87,7 @@ All four fields have been added to the form. The **fulfiller users** should be h
    ![](../images/2023-12-05-13-51-33.png)
 
 
-7. Move 'Approvers' from the left side to the right side. 
+7. Move 'Approvers' from the left side to the right side. Then click <span className="button-purple">Save</span>.
 ![](../images/2023-12-05-13-56-48.png)
 
 

--- a/labs/telework-vancouver-101/2.0-The-User-Experience/2.0-Overview.md
+++ b/labs/telework-vancouver-101/2.0-The-User-Experience/2.0-Overview.md
@@ -9,7 +9,7 @@ draft: false
 
 In the Use Case story we are following, Amanda's team wants to replace the paper form that users have to submit to Telework.
 
-In this exercise, we will create a digital form for for users to submit new Telework Case requests from an end user portal. 
+In this exercise, we will create a digital form for users to submit new Telework Case requests from an end user portal. 
 
 :::tip
 The form you will create is called a **Record Producer** in ServiceNow terminology.

--- a/labs/telework-vancouver-101/2.0-The-User-Experience/2.5-review.md
+++ b/labs/telework-vancouver-101/2.0-The-User-Experience/2.5-review.md
@@ -8,7 +8,7 @@ draft: false
 
 In the Use Case story we are following, Amanda's team wanted to replace the paper form that users have to submit to Telework.
 
-In this exercise, you created a digital form called a **Record Producer** for for users to submit new Telework Case requests.
+In this exercise, you created a digital form called a **Record Producer** for users to submit new Telework Case requests.
 
 The Record Producer contains the questions provided by Amanda and her team of **fulfillers** as well as UI Behaviors and input validation. 
 

--- a/labs/telework-vancouver-101/3.0-Automate-Work/3.1-create-flow.md
+++ b/labs/telework-vancouver-101/3.0-Automate-Work/3.1-create-flow.md
@@ -224,8 +224,10 @@ Adding Annotations makes the Flow easier to read.
     ![](../images/2023-11-08_14-55-21.gif)
 
     :::
+    
     **RESULT:**
     ![](../images/2023-11-03-16-37-31.png)
+
     16.  In the **Body** field, press Enter to move to the cursor to the next line.
     17.  Type `Your application for ` _(Be sure to include the extra space at the end)_.
     ![](../images/2023-11-03-16-39-09.png)

--- a/labs/telework-vancouver-101/3.0-Automate-Work/3.2-test-flow.md
+++ b/labs/telework-vancouver-101/3.0-Automate-Work/3.2-test-flow.md
@@ -7,7 +7,7 @@ draft: false
 
 ## Overview
 
-In this section, we will test the flow we just created and make sure it functions as expected. We need to test with a user who has a manger. Fortunately ServiceNow allows admins to impersonate other authenticated users for testing purposes.
+In this section, we will test the flow we just created and make sure it functions as expected. We need to test with a user who has a manager. Fortunately ServiceNow allows admins to impersonate other authenticated users for testing purposes.
 
 In our use case story, you will assume the role of 'David Loo'. He recently learned his child has a minor sickness and will need to stay home for a few days.
 

--- a/labs/telework-vancouver-101/4.0-Manage-Work/4.4-use.md
+++ b/labs/telework-vancouver-101/4.0-Manage-Work/4.4-use.md
@@ -62,7 +62,7 @@ We need to reassign his work to another case worker. (_It is hard to do when the
 
     1. Select all rows
     2. Click **Edit** 
-    3. type **and**
+    3. Find the **Assigned to** field and type **and**
     4. Select "Andrew Och"
     5. Click Update.
     ![](../images/2023-11-08-20-46-13.png)

--- a/labs/telework-vancouver-101/5.0-conclusion/00-lab-review.md
+++ b/labs/telework-vancouver-101/5.0-conclusion/00-lab-review.md
@@ -5,7 +5,7 @@ hide_table_of_contents: true
 draft: false
 ---
 
-In this lab, we built, implemented, and tested an application using the fundamental part of an application: Data, User Experience, and Automation.
+In this lab, we built, implemented, and tested an application using the fundamental parts of an application: Data, User Experience, and Automation.
 
 The team managing the work will be more efficient and the users will get what they need faster.
 


### PR DESCRIPTION
- fixed typos, added save, fixed numbering formatting
- NOTE: Did NOT have a chance to fix Section 4.2 Steps 5-8 because columns were in a different order when we first opened up the workspace due to configuring the global list layout in exercise 1.4 (@dalestubblefield - I'll talk to you to figure out how we want to fix this)